### PR TITLE
fix: add format to character's name when resting ("cannot attack")

### DIFF
--- a/src/Bard.java
+++ b/src/Bard.java
@@ -41,7 +41,7 @@ public class Bard {
                 "Once more, the clash of titans echoes across the realm, as the cycle of battle begins anew.\n");
     }
     public static void narratesRest(Character attacker) {
-        System.out.printf("%s cannot attack \uD83E\uDDD8\n", attacker.getName());
+        System.out.printf("%s cannot attack \uD83E\uDDD8\n", getStyledNameForCharacter(attacker));
     }
 
     private static String getStyledNameForCharacter(Character character) {


### PR DESCRIPTION
Add format (color & brackets) to character's name when they cannot attack 💅